### PR TITLE
Update GitHub registry workflow token and registry setup

### DIFF
--- a/.github/workflows/github-registry.yml
+++ b/.github/workflows/github-registry.yml
@@ -24,9 +24,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.1
-          registries: |
-            https://registry.npmjs.org/
-            @escendit:https://npm.pkg.github.com/|$GITHUB_TOKEN
       # Install dependencies
       - name: Install dependencies
         run: bun install
@@ -43,5 +40,5 @@ jobs:
       # Publish
       - name: Publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bun publish
+          NPM_CONFIG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun publish --registry https://npm.pkg.github.com/


### PR DESCRIPTION
Closes #5

## Summary by Sourcery

Update GitHub Actions workflow to correctly authenticate and target the GitHub package registry when publishing with bun

CI:
- Remove redundant registries configuration from the setup-bun step
- Use NPM_CONFIG_TOKEN environment variable for authentication during publish
- Add explicit --registry flag pointing to GitHub package registry in bun publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing workflow configuration to enhance deployment security and reliability by refining authentication methods and explicit registry targeting for automated releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->