### PR TITLE
Update npm publish workflow with .npmrc setup

### DIFF
--- a/.github/workflows/github-registry.yml
+++ b/.github/workflows/github-registry.yml
@@ -37,8 +37,13 @@ jobs:
         run: echo "VERSION=${TAG#v}" >> $GITHUB_ENV
       - name: Set Version
         run: npm version $VERSION --no-git-tag-version
+      # Setup npmrc
+      - name: Create .npmrc
+        run: |
+          {
+            echo "@${{ github.repository_owner }}:registry=https://npm.pkg.github.com"
+            echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}"
+          } | tee -a .npmrc
       # Publish
       - name: Publish
-        env:
-          NPM_CONFIG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bun publish --registry https://npm.pkg.github.com/
+        run: npm publish


### PR DESCRIPTION
Closes #7

## Summary by Sourcery

Configure npm authentication in GitHub Actions by generating a .npmrc file and simplify the publish step to use npm publish.

CI:
- Add a workflow step to create .npmrc with the GitHub Packages registry and auth token
- Replace the bun publish command and NPM_CONFIG_TOKEN env var with a direct npm publish invocation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing workflow configuration to improve deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->