### PR TITLE
Clean up and streamline GitHub registry workflow logic

### DIFF
--- a/.github/workflows/github-registry.yml
+++ b/.github/workflows/github-registry.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 jobs:
   pack:
-    # if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
     name: "Pack"
     runs-on: ubuntu-latest
     steps:
@@ -28,11 +28,8 @@ jobs:
       - name: Install dependencies
         run: bun install
       # Set Version
-      - name: Set TAG variable (default)
-        run: echo "TAG=v0.0.1" >> $GITHUB_ENV
       - name: Set TAG variable
         run: echo "TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
-        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
       - name: Set VERSION variable
         run: echo "VERSION=${TAG#v}" >> $GITHUB_ENV
       - name: Set Version


### PR DESCRIPTION
Closes #11

## Summary by Sourcery

Streamline the GitHub registry workflow by removing unnecessary default TAG logic and redundant conditionals, and ensure the ‘pack’ job triggers solely on published release events using the actual release tag to set TAG and derive VERSION.

Enhancements:
- Remove commented and hardcoded default TAG assignment in the ‘pack’ job
- Eliminate redundant conditional on the TAG-setting step
- Derive TAG from github.event.release.tag_name and set VERSION by stripping the ‘v’ prefix

CI:
- Simplify the ‘pack’ job trigger to run only on release published events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to refine release automation and tag handling processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->