### PR TITLE
Add a monthly label to update the workflow

### DIFF
--- a/.github/workflows/cron-update-labels.yml
+++ b/.github/workflows/cron-update-labels.yml
@@ -1,0 +1,26 @@
+# Utility that updates labels based on keystone repository with reusable workflows
+name: "Monthly Label Timer"
+on:
+  # Manually run the job
+  workflow_dispatch:
+  # Periodically run the job
+  # Every first day of the month at 1:32 UTC
+  schedule:
+    - cron: "32 1 1 * *"
+
+# Prevent Concurrent Jobs
+concurrency:
+  group: labels-monthly-${{ github.ref }}
+  cancel-in-progress: true
+
+# Grant only what’s needed; label management requires issues: write
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  # Runs reusable workflow (utility-update-labels.yml on the main branch) from keystone repository
+  create-labels:
+    name: "Update Labels"
+    uses: escendit/keystone/.github/workflows/utility-update-labels.yml@main
+    secrets: inherit


### PR DESCRIPTION
Closes #13

## Summary by Sourcery

Add a new GitHub Actions workflow that triggers monthly and on demand to update issue labels using the keystone reusable workflow

CI:
- Introduce 'Monthly Label Timer' workflow to run on manual dispatch and on the first day of each month at 1:32 UTC
- Configure concurrency and minimal permissions for the label update job
- Invoke the keystone repository's utility-update-labels reusable workflow with inherited secrets