### PR TITLE
Add npm registry workflow for automatic package publishing

### DIFF
--- a/.github/workflows/npm-registry.yml
+++ b/.github/workflows/npm-registry.yml
@@ -1,0 +1,40 @@
+name: "npm"
+
+on:
+  workflow_run:
+    workflows:
+      - "Release"
+    types:
+      - completed
+permissions:
+  contents: read
+jobs:
+  pack:
+    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    name: "Pack"
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      # Setup Bun
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.1
+      # Install dependencies
+      - name: Install dependencies
+        run: bun install
+      # Set Version
+      - name: Set TAG variable
+        run: echo "TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+      - name: Set VERSION variable
+        run: echo "VERSION=${TAG#v}" >> $GITHUB_ENV
+      - name: Set Version
+        run: npm version $VERSION --no-git-tag-version
+      # Publish
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Closes #22

## Summary by Sourcery

CI:
- Introduce npm-registry GitHub Action triggered on completed release to set version and publish package to npm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated npm package publishing workflow. Releases now automatically publish to npm registry with proper versioning, streamlining the distribution process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->